### PR TITLE
Add prefix/suffix to contracts name capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The plugin accepts the following configuration:
 
 -   `include_networks:` an array of exported filename(s) without the .json extension to include in the output file.
 -   `exclude_networks:` an array of exported filename(s) without the .json extension to exclude from the output file.
+-   `prefix_contracts:` A string to be prepended to the contract name. Help avoid name collisions and improve intellisense when supporting multiple major versions of the same library.
+-   `suffix_contracts:` A string to be appended to the contract name. Help avoid name collisions and improve intellisense when supporting multiple major versions of the same library.
 
 ## License
 


### PR DESCRIPTION
## Summary

Code changes to support adding a prefix and/or suffix to the contract names. The reasoning is that, in my case, I support different major versions of a project, and even though the addresses of contracts had changed, the name of such contracts did not, making it prone to undesired overwrites when maintaining multiple versions, thus, the need to have a way to decide how you want to distinguish such contracts freely. Also, in my case, a prefix facilitates IDE `IntelliSense` with quick autocomplete filtering (GIF below). Nonetheless, I also included a "suffix" option (One should choose their destiny)

#### Intellisense in action
![2024-12-10 10 09 57](https://github.com/user-attachments/assets/c3d377cd-95df-4339-9253-1ea647686c4d)
